### PR TITLE
Issue #224: stacktrace elimination for missing datastream

### DIFF
--- a/search/src/java/cz/incad/Kramerius/imaging/ImageStreamsServlet.java
+++ b/search/src/java/cz/incad/Kramerius/imaging/ImageStreamsServlet.java
@@ -150,7 +150,7 @@ public class ImageStreamsServlet extends AbstractImageServlet {
                     actionToDo.doPerform(this, this.fedoraAccess, pid, stream, page, req, resp);
                 } catch (FedoraIOException e1) {
                     // fedora exception
-                    LOGGER.log(Level.SEVERE, e1.getMessage(), e1);
+                    LOGGER.log(Level.WARNING, "Missing " + stream + " datastream for " + pid);
                     resp.setStatus(e1.getContentResponseCode());
                     resp.getWriter().write(e1.getContentResponseBody());
                 } catch (FileNotFoundException e1) {


### PR DESCRIPTION
Tento PR odstraňuje zbytečný stacktrace pro objecty, kterým chybí požadovaný datastream. Otestováno na produkci. 