### PR TITLE
Fix mw-process indexing

### DIFF
--- a/mw-process/src/main/java/cz/cas/lib/knav/indexer/CollectPidForIndexing.java
+++ b/mw-process/src/main/java/cz/cas/lib/knav/indexer/CollectPidForIndexing.java
@@ -22,7 +22,7 @@ import cz.incad.kramerius.service.impl.IndexerProcessStarter.TokensFilter;
  */
 public class CollectPidForIndexing {
 
-    public static final int MAXIMUM_DOCUMENTS = 100;
+    public static final int MAXIMUM_DOCUMENTS = 90;
 
     
     private List<String> collectedPids = new ArrayList<String>();


### PR DESCRIPTION
V pripade ze sa nazbiera 100 uuid na reindexaciu sa tento proces s parametrami nevojde do databaze. Preto znizenie poctu na 90.